### PR TITLE
Schedules: allow null repeat_cycles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,4 @@ __pycache__/*
 *.env
 *.db
 .coverage
-load_data.py
 .envrc

--- a/petsrus/models/models.py
+++ b/petsrus/models/models.py
@@ -102,7 +102,7 @@ class Schedule(Base):
     pet_id = Column(Integer, ForeignKey("pets.id"), nullable=False)
     date_of_next = Column(Date(), nullable=False)
     repeats = Column(String(3), nullable=False)
-    repeat_cycle = Column(String(10), nullable=False)
+    repeat_cycle = Column(String(10), nullable=True)
     schedule_type = Column(String(10), nullable=False)
 
     def __repr__(self):

--- a/petsrus/templates/pet_details.html
+++ b/petsrus/templates/pet_details.html
@@ -73,7 +73,11 @@
                   <td>{{schedule.schedule_type|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
-                  <td>{{schedule.repeat_cycle}}</td>
+                  {% if schedule.repeat_cycle %}
+                    <td>{{schedule.repeat_cycle}}</td>
+                  {% else %}
+                    <td>&mdash;</td>
+                  {% endif %}
                   <td><button
                           type="button"
                           class="btn btn-danger"
@@ -137,7 +141,11 @@
                   <td>{{schedule.schedule_type|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
-                  <td>{{schedule.repeat_cycle}}</td>
+                  {% if schedule.repeat_cycle %}
+                    <td>{{schedule.repeat_cycle}}</td>
+                  {% else %}
+                    <td>&mdash;</td>
+                  {% endif %}
                   <td>&nbsp;</td>
               </tr>
             {% endfor %}

--- a/petsrus/tests/helper.py
+++ b/petsrus/tests/helper.py
@@ -65,7 +65,7 @@ def random_schedule(past=False):
         if repeat_cycle == "YEARLY":
             schedule_type = "VACCINE"
     else:
-        repeat_cycle = ""
+        repeat_cycle = None
     # We want some historical schedules
     if past:
         date_of_next = fake.date_this_year(before_today=True, after_today=False)

--- a/petsrus/tests/test_pets.py
+++ b/petsrus/tests/test_pets.py
@@ -20,6 +20,10 @@ class TestCasePets(unittest.TestCase):
         self.client = app.test_client()
         self.client.testing = True
         self.db_session = db_session
+        self.db_session.query(Schedule).delete()
+        self.db_session.query(Pet).delete()
+        self.db_session.query(User).delete()
+        self.db_session.commit()
 
     def tearDown(self):
         self.db_session.query(Schedule).delete()
@@ -590,7 +594,7 @@ class TestCasePets(unittest.TestCase):
                 schedule_type="FRONTLINE",
                 date_of_next=date.today() + timedelta(days=2),
                 repeats="NO",
-                repeat_cycle="",
+                repeat_cycle=None,
             ),
             follow_redirects=True,
         )

--- a/petsrus/tests/test_users.py
+++ b/petsrus/tests/test_users.py
@@ -1,10 +1,10 @@
 # coding=utf-8
 import unittest
 
+from petsrus.models.models import User
 from petsrus.petsrus import app
-from petsrus.models.models import Pet, User
+from petsrus.tests.helper import login_user_helper, register_user_helper
 from petsrus.views.main import db_session
-from petsrus.tests.helper import register_user_helper, login_user_helper
 
 
 class TestCaseUsers(unittest.TestCase):
@@ -12,10 +12,11 @@ class TestCaseUsers(unittest.TestCase):
         self.client = app.test_client()
         self.client.testing = True
         self.db_session = db_session
+        self.db_session.query(User).delete()
+        self.db_session.commit()
 
     def tearDown(self):
         self.db_session.query(User).delete()
-        self.db_session.query(Pet).delete()
         self.db_session.commit()
         self.db_session.close()
 


### PR DESCRIPTION


**Technical Description**

Fix issue where we are not able to save schedules that do not repeat.

Issue: https://github.com/Eorate/petsrus/issues/59
