### PR TITLE
Fix issue 76 delete pets with schedules

### DIFF
--- a/petsrus/models/models.py
+++ b/petsrus/models/models.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from sqlalchemy import Boolean, Column, Date, ForeignKey, Integer, String, Text
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
@@ -81,6 +82,10 @@ class Pet(Base):
     sex = Column(String(1), nullable=False)
     colour_and_identifying_marks = Column(String(200), nullable=False)
     photo = Column(Text, nullable=True, default="default.png")
+
+    schedules = relationship(
+        "Schedule", backref="pet", cascade="all, delete, delete-orphan"
+    )
 
     def __repr__(self):
         return (

--- a/petsrus/templates/index.html
+++ b/petsrus/templates/index.html
@@ -75,7 +75,10 @@
 
                         <!-- Modal body -->
                         <div class="modal-body">
-                            Are you sure you want to delete <b>{{pet.name}}</b>?
+                            Are you sure you want to delete <b>{{pet.name}}'s</b> pet details including and their schedules?
+                            <br />
+                            <br />
+                            <span class="text-danger small font-weight-bold">This action can not be undone.</span>
                         </div>
 
                         <!-- Modal footer -->

--- a/petsrus/views/main.py
+++ b/petsrus/views/main.py
@@ -229,17 +229,15 @@ def view_pet(pet_id):
 def delete_pet(pet_id):
     if request.method == "POST":
         try:
-            schedule = db_session.query(Schedule).get(pet_id)
             pet = db_session.query(Pet).get(pet_id)
-            if schedule:
-                db_session.delete(schedule)
             db_session.delete(pet)
             db_session.commit()
             flash("Deleted Pet Details", "success")
-            return redirect(url_for("index"))
         except Exception as exc:
+            flash("An unexpected issue occured while attempting to delete", "danger")
             app.logger.error(traceback.format_exc)
             capture_exception(exc)
+        return redirect(url_for("index"))
 
 
 @app.route("/add_schedule/<int:pet_id>", methods=["GET", "POST"])
@@ -262,7 +260,7 @@ def add_schedule(pet_id):
             db_session.add(pet_schedule)
             db_session.commit()
             flash("Saved Pet Schedule", "success")
-            return redirect(url_for("index"))
+            return redirect(url_for("view_pet", pet_id=pet_id))
         except Exception as exc:
             app.logger.error(traceback.format_exc)
             capture_exception(exc)
@@ -279,7 +277,7 @@ def delete_schedule(schedule_id):
             db_session.delete(schedule)
             db_session.commit()
             flash("Deleted Pet Schedule", "success")
-            return redirect(url_for("index"))
+            return redirect(url_for("view_pet", pet_id=schedule.pet_id))
     except Exception as exc:
         app.logger.error(traceback.format_exc)
         capture_exception(exc)

--- a/petsrus/views/main.py
+++ b/petsrus/views/main.py
@@ -235,8 +235,11 @@ def delete_pet(pet_id):
             db_session.commit()
             flash("Deleted Pet Details", "success")
         except Exception as exc:
-            flash("An unexpected issue occured while attempting to delete", "danger")
-            app.logger.error(traceback.format_exc)
+            flash(
+                "An unexpected issue occured while attempting to delete this pet",
+                "danger",
+            )
+            app.logger.error(traceback.format_exc())
             capture_exception(exc)
         return redirect(url_for("index"))
 
@@ -272,16 +275,20 @@ def add_schedule(pet_id):
 @app.route("/delete_schedule/<int:schedule_id>", methods=["POST"])
 @login_required
 def delete_schedule(schedule_id):
-    try:
-        if request.method == "POST":
-            schedule = db_session.query(Schedule).get(schedule_id)
+    if request.method == "POST":
+        schedule = db_session.query(Schedule).get(schedule_id)
+        try:
             db_session.delete(schedule)
             db_session.commit()
             flash("Deleted Pet Schedule", "success")
-            return redirect(url_for("view_pet", pet_id=schedule.pet_id))
-    except Exception as exc:
-        app.logger.error(traceback.format_exc)
-        capture_exception(exc)
+        except Exception as exc:
+            flash(
+                "An unexpected issue occured while attempting to delete a schedule",
+                "danger",
+            )
+            app.logger.error(traceback.format_exc())
+            capture_exception(exc)
+        return redirect(url_for("view_pet", pet_id=schedule.pet_id))
 
 
 @app.route("/", methods=["GET", "POST"])


### PR DESCRIPTION
**Technical Description**

This PR fixes 
1. An issue that was raised where we were not able to delete pets who have schedules saved. It also addresses that fact that we now have flash messages when we get unexpected errors. 
2. It was also noted that on addition and deletion of schedules, we are redirected back to the list of pets instead of going back to the pet detail page that we were on. 

**Reference**

Issue: https://github.com/Eorate/petsrus/issues/76
