### PR TITLE
fix: use the correct name for semantic release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,9 @@ jobs:
           name: Deploy to Heroku
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-                . venv/bin/activate
                 git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
-                semantic_release publish
+                . venv/bin/activate
+                semantic-release publish
             fi
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then
                 git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_STAGING_APP_NAME.git master


### PR DESCRIPTION
**Technical Description**

This fixes the issue where the wrong command name was being used to call
semantic-release thus causing the deploy to Heroku to fail.

**Reference**

Trello: https://trello.com/c/Pv8cyYSR/13-update-revision-automatically
