### PR TITLE
fix(semantic-release): deploy issue with empty identity

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,8 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
                 git push -f https://heroku:$HEROKU_API_KEY@git.heroku.com/$HEROKU_APP_NAME.git master
                 . venv/bin/activate
+                git config user.email "Tharlaw@example.com"
+                git config user.name "Tharlaw"
                 semantic-release publish
             fi
             if [ "${CIRCLE_BRANCH}" == "develop" ]; then


### PR DESCRIPTION


**Technical Description**

Addresses this issue: https://github.com/Eorate/petsrus/issues/90

Where semantic-release fails to commit changes back to git as the
identity details ie name and email address are not set.

**Reference**

Trello: https://trello.com/c/Pv8cyYSR/13-update-revision-automatically
