### PR TITLE
chore: Switch to Trello cards as reference

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,4 +4,4 @@ Why is the PR needed.
 
 **Reference**
 
-Pivotaltracker: `<link to PT story>`
+Trello: `<link to Trello Card>`


### PR DESCRIPTION


**Technical Description**

As we had switched to Trello, we now finally update the references
section of our PR template

**Reference**

Trello: https://trello.com/c/iMXbo2YR/15-housekeeping
