### PR TITLE
chore: Read schedule types from database

### DIFF
--- a/petsrus/forms/forms.py
+++ b/petsrus/forms/forms.py
@@ -2,14 +2,25 @@ from datetime import date
 
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
-from wtforms import (IntegerField, PasswordField, RadioField, SelectField,
-                     StringField, SubmitField)
-from wtforms.fields.html5 import DateField
-from wtforms.validators import (DataRequired, Email, EqualTo, InputRequired,
-                                Length, Optional)
-
 from petsrus.forms.validators import FutureDate, PastDate
-from petsrus.models.models import Repeat, Repeat_cycle, Schedule_type
+from petsrus.models.models import Repeat, Repeat_cycle
+from wtforms import (
+    IntegerField,
+    PasswordField,
+    RadioField,
+    SelectField,
+    StringField,
+    SubmitField,
+)
+from wtforms.fields.html5 import DateField
+from wtforms.validators import (
+    DataRequired,
+    Email,
+    EqualTo,
+    InputRequired,
+    Length,
+    Optional,
+)
 
 
 class RegistrationForm(FlaskForm):
@@ -129,7 +140,7 @@ class PetScheduleForm(FlaskForm):
     repeat_cycle = RadioField(
         "Repeat Cycle:", choices=Repeat_cycle.__values__, validators=[Optional()]
     )
-    schedule_type = SelectField(choices=Schedule_type.__values__)
+    schedule_type = SelectField(u"Schedule Types", coerce=int)
     save = SubmitField("Save")
 
 

--- a/petsrus/models/models.py
+++ b/petsrus/models/models.py
@@ -29,20 +29,10 @@ class Repeat(Enum):
     YES = "Yes"
     NO = "No"
 
-    @classproperty
-    def __values__(cls):
-        return [(repeat.name, repeat.value) for repeat in cls]
-
-
-class Schedule_type(Enum):
-    VACCINE = "Vaccine"
-    DEWORMING = "Deworming"
-    FRONTLINE = "Frontline"
-
     # http://xion.io/post/code/python-enums-are-ok.html
     @classproperty
     def __values__(cls):
-        return [(schedule_type.name, schedule_type.value) for schedule_type in cls]
+        return [(repeat.name, repeat.value) for repeat in cls]
 
 
 class User(Base):
@@ -110,17 +100,31 @@ class Schedule(Base):
     date_of_next = Column(Date(), nullable=False)
     repeats = Column(String(3), nullable=False)
     repeat_cycle = Column(String(10), nullable=True)
-    schedule_type = Column(String(10), nullable=False)
+    schedule_type = Column(Integer, ForeignKey("schedule_types.id"), nullable=True)
+
+    schedule_types = relationship("ScheduleType", backref="schedule_types")
 
     def __repr__(self):
         return (
             "<Schedule\nid: {}\npet_id: {}\ndate_of_next: {}\nrepeats: {}\n"
-            "repeat_cycle: {}\nschedule_type: {}\n>"
+            "repeat_cycle: {}\nschedule_type_id:{}\nschedule_type_name: {}\n>"
         ).format(
             self.id,
             self.pet_id,
             self.date_of_next,
             self.repeats,
             self.repeat_cycle,
-            self.schedule_type,
+            self.schedule_types.id,
+            self.schedule_types.name,
+        )
+
+
+class ScheduleType(Base):
+    __tablename__ = "schedule_types"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(20), nullable=False)
+
+    def __repr__(self):
+        return ("<ScheduleType\nid: {}\nschedule_type: {}\n>").format(
+            self.id, self.name,
         )

--- a/petsrus/templates/pet_details.html
+++ b/petsrus/templates/pet_details.html
@@ -128,7 +128,7 @@
             <tbody>
                 {% for schedule in due_schedules %}
               <tr>
-                  <td>{{schedule.schedule_type|title}}</td>
+                  <td>{{schedule.schedule_types.name|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
                   {% if schedule.repeat_cycle %}
@@ -198,7 +198,7 @@
             <tbody>
                 {% for schedule in past_schedules %}
               <tr>
-                  <td>{{schedule.schedule_type|title}}</td>
+                  <td>{{schedule.schedule_types.name|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
                   {% if schedule.repeat_cycle %}

--- a/petsrus/tests/create_data.py
+++ b/petsrus/tests/create_data.py
@@ -5,15 +5,19 @@
 import os
 import random
 
-from werkzeug.security import generate_password_hash
-
-from petsrus.models.models import Pet, Schedule, User
-from petsrus.tests.helper import (add_pet_helper, add_pet_schedule_helper,
-                                  random_pet, random_schedule)
+from petsrus.models.models import Pet, Schedule, ScheduleType, User
+from petsrus.tests.helper import (
+    add_pet_helper,
+    add_pet_schedule_helper,
+    random_pet,
+    random_schedule,
+)
 from petsrus.views.main import db_session
+from werkzeug.security import generate_password_hash
 
 # Drop previous data
 db_session.query(Schedule).delete()
+db_session.query(ScheduleType).delete()
 db_session.query(Pet).delete()
 db_session.query(User).delete()
 
@@ -25,13 +29,20 @@ user = User(
 )
 
 db_session.add(user)
+
+for schedule_type_name in ["Vaccine", "Deworming", "Frontline"]:
+    schedule_type = ScheduleType(name=schedule_type_name)
+    db_session.add(schedule_type)
+
 db_session.commit()
 
 for _ in range(5):
     pet = add_pet_helper(db_session, random_pet())
     for _ in range(random.randint(1, 3)):
-        due_schedule = add_pet_schedule_helper(db_session, pet, random_schedule())
+        due_schedule = add_pet_schedule_helper(
+            db_session, pet, random_schedule(db_session)
+        )
     for _ in range(random.randint(1, 5)):
         past_schedule = add_pet_schedule_helper(
-            db_session, pet, random_schedule(past=True)
+            db_session, pet, random_schedule(db_session, past=True)
         )

--- a/petsrus/tests/helper.py
+++ b/petsrus/tests/helper.py
@@ -2,8 +2,7 @@
 import random
 
 from faker import Faker
-
-from petsrus.models.models import Pet, Schedule
+from petsrus.models.models import Pet, Schedule, ScheduleType
 
 fake = Faker()
 
@@ -52,18 +51,17 @@ def random_pet():
     }
 
 
-def random_schedule(past=False):
+def random_schedule(db_session, past=False):
     """Create random pet schedules"""
-    schedule_type = fake.random_choices(
-        elements=("VACCINE", "DEWORMING", "FRONTLINE"), length=1
-    )[0]
+    schedule_types = [
+        schedule_type.id for schedule_type in db_session.query(ScheduleType).all()
+    ]
+    schedule_type = fake.random_choices(elements=schedule_types, length=1)[0]
     repeats = "YES" if random.randint(0, 1) == 0 else "NO"
     if repeats == "YES":
         repeat_cycle = fake.random_choices(
             elements=("MONTHLY", "QUARTERLY", "YEARLY"), length=1
         )[0]
-        if repeat_cycle == "YEARLY":
-            schedule_type = "VACCINE"
     else:
         repeat_cycle = None
     # We want some historical schedules

--- a/petsrus/tests/test_users.py
+++ b/petsrus/tests/test_users.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import logging
 import unittest
 
 from petsrus.models.models import User


### PR DESCRIPTION


**Technical Description**

We are now reading the schedule types from the database. The unit tests
have been updated to add to and read from the database as well.

**Reference**

Trello: https://trello.com/c/0himenlq/4-schedule-types-move-to-database
