### PR TITLE
fix: Return 404 error for unknown pets

### DIFF
--- a/petsrus/templates/404.html
+++ b/petsrus/templates/404.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+
+{% block title %} PetsRUs - Page Not Found
+{% endblock %}
+
+{% block navbar_content %}
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#collapsibleNavbar">
+        <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="collapsibleNavbar">
+         <ul class="navbar-nav">
+          <li class="nav-item">
+            <a href="{{ url_for('index') }}" class="nav-item nav-link">Home</a>
+          </li>
+        </ul>
+         <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+              <span class="nav-item nav-link disabled"> Logged in as: {{ current_user.username }}</span>
+          </li>
+          <li class="nav-item">
+            <a href="{{ url_for('logout') }}" class="nav-item nav-link">Logout</a>
+          </li>
+        </ul>
+    </div>
+{% endblock %}
+
+{% block content %}
+
+    <div class="container p-3">
+        <h5>{{message}}</h5>
+
+    </div>
+
+{% endblock %}

--- a/petsrus/tests/test_pets.py
+++ b/petsrus/tests/test_pets.py
@@ -542,6 +542,14 @@ class TestCasePets(unittest.TestCase):
             in response.get_data(as_text=True)
         )
 
+        # Attempting to view unknown pets should return a 404
+        response = self.client.get("/view_pet/{}".format(0))
+        self.assertEqual(response.status_code, 404)
+        self.assertTrue(
+            "h5>{}</h5".format("Sorry, Pet does not exist.")
+            in response.get_data(as_text=True)
+        )
+
         response = self.client.get("/logout")
         self.assertEqual(response.status_code, 302)
 

--- a/petsrus/views/main.py
+++ b/petsrus/views/main.py
@@ -191,10 +191,18 @@ def update_pet_photo(pet_id):
         return redirect(url_for("view_pet", pet_id=pet_id))
 
 
+@app.errorhandler(404)
+def page_not_found(error):
+    return render_template("404.html", message=error), 404
+
+
 @app.route("/view_pet/<int:pet_id>", methods=["GET"])
 @login_required
 def view_pet(pet_id):
     pet = db_session.query(Pet).filter_by(id=pet_id).first()
+    if pet is None:
+        return page_not_found("Sorry, Pet does not exist.")
+
     form = ChangePetPhotoForm()
     due = (
         db_session.query(Schedule)


### PR DESCRIPTION

**Technical Description**

When we attempt to request for pet ids that do not exist, we should get a 404 error instead of a 500. This PR fixes the reported issue.

**Reference**

Issue: https://github.com/Eorate/petsrus/issues/98
