### PR TITLE
chore: Read repeat cycles from database

### DIFF
--- a/alembic/versions/73340f5f1adf_change_schedules_repeat_cycle_column.py
+++ b/alembic/versions/73340f5f1adf_change_schedules_repeat_cycle_column.py
@@ -1,0 +1,25 @@
+"""change_schedules_repeat_cycle_column
+
+Revision ID: 73340f5f1adf
+Revises: acf23daeb12b
+Create Date: 2020-08-23 12:09:49.948494
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "73340f5f1adf"
+down_revision = "acf23daeb12b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_column("schedules", "repeat_cycle")
+    op.add_column("schedules", sa.Column("repeat_cycle", sa.Integer, nullable=True))
+
+
+def downgrade():
+    op.drop_column("schedules", "repeat_cycle")
+    op.add_column("schedules", sa.Column("repeat_cycle", sa.String(10), nullable=True))

--- a/petsrus/forms/forms.py
+++ b/petsrus/forms/forms.py
@@ -3,7 +3,7 @@ from datetime import date
 from flask_wtf import FlaskForm
 from flask_wtf.file import FileField
 from petsrus.forms.validators import FutureDate, PastDate
-from petsrus.models.models import Repeat, Repeat_cycle
+from petsrus.models.models import Repeat
 from wtforms import (
     IntegerField,
     PasswordField,
@@ -137,9 +137,7 @@ class PetScheduleForm(FlaskForm):
         choices=Repeat.__values__,
         validators=[InputRequired(message="Please select either Yes or No")],
     )
-    repeat_cycle = RadioField(
-        "Repeat Cycle:", choices=Repeat_cycle.__values__, validators=[Optional()]
-    )
+    repeat_cycle = RadioField(u"Repeat Cycle:", coerce=int, validators=[Optional()])
     schedule_type = SelectField(u"Schedule Types", coerce=int)
     save = SubmitField("Save")
 

--- a/petsrus/models/models.py
+++ b/petsrus/models/models.py
@@ -15,16 +15,6 @@ class classproperty:
         return self._func(owner)
 
 
-class Repeat_cycle(Enum):
-    MONTHLY = "Monthly"
-    QUARTERLY = "Quarterly"
-    YEARLY = "Yearly"
-
-    @classproperty
-    def __values__(cls):
-        return [(repeat_cycle.name, repeat_cycle.value) for repeat_cycle in cls]
-
-
 class Repeat(Enum):
     YES = "Yes"
     NO = "No"
@@ -99,10 +89,11 @@ class Schedule(Base):
     pet_id = Column(Integer, ForeignKey("pets.id"), nullable=False)
     date_of_next = Column(Date(), nullable=False)
     repeats = Column(String(3), nullable=False)
-    repeat_cycle = Column(String(10), nullable=True)
+    repeat_cycle = Column(Integer, ForeignKey("repeat_cycles.id"), nullable=True)
     schedule_type = Column(Integer, ForeignKey("schedule_types.id"), nullable=True)
 
     schedule_types = relationship("ScheduleType", backref="schedule_types")
+    repeat_cycles = relationship("RepeatCycle", backref="repeat_cycles")
 
     def __repr__(self):
         return (
@@ -113,7 +104,8 @@ class Schedule(Base):
             self.pet_id,
             self.date_of_next,
             self.repeats,
-            self.repeat_cycle,
+            self.repeat_cycles.id,
+            self.repeat_cycles.name,
             self.schedule_types.id,
             self.schedule_types.name,
         )
@@ -128,3 +120,12 @@ class ScheduleType(Base):
         return ("<ScheduleType\nid: {}\nschedule_type: {}\n>").format(
             self.id, self.name,
         )
+
+
+class RepeatCycle(Base):
+    __tablename__ = "repeat_cycles"
+    id = Column(Integer, primary_key=True)
+    name = Column(String(20), nullable=False)
+
+    def __repr__(self):
+        return ("<RepeatCycle\nid: {}\nrepeat_cycle: {}\n>").format(self.id, self.name,)

--- a/petsrus/templates/pet_details.html
+++ b/petsrus/templates/pet_details.html
@@ -131,8 +131,8 @@
                   <td>{{schedule.schedule_types.name|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
-                  {% if schedule.repeat_cycle %}
-                    <td>{{schedule.repeat_cycle}}</td>
+                  {% if schedule.repeat_cycles.name %}
+                    <td>{{schedule.repeat_cycles.name}}</td>
                   {% else %}
                     <td>&mdash;</td>
                   {% endif %}
@@ -201,8 +201,8 @@
                   <td>{{schedule.schedule_types.name|title}}</td>
                   <td>{{schedule.date_of_next}}</td>
                   <td>{{schedule.repeats}}</td>
-                  {% if schedule.repeat_cycle %}
-                    <td>{{schedule.repeat_cycle}}</td>
+                  {% if schedule.repeat_cycles.name %}
+                    <td>{{schedule.repeat_cycles.name}}</td>
                   {% else %}
                     <td>&mdash;</td>
                   {% endif %}

--- a/petsrus/tests/create_data.py
+++ b/petsrus/tests/create_data.py
@@ -5,7 +5,7 @@
 import os
 import random
 
-from petsrus.models.models import Pet, Schedule, ScheduleType, User
+from petsrus.models.models import Pet, RepeatCycle, Schedule, ScheduleType, User
 from petsrus.tests.helper import (
     add_pet_helper,
     add_pet_schedule_helper,
@@ -18,6 +18,7 @@ from werkzeug.security import generate_password_hash
 # Drop previous data
 db_session.query(Schedule).delete()
 db_session.query(ScheduleType).delete()
+db_session.query(RepeatCycle).delete()
 db_session.query(Pet).delete()
 db_session.query(User).delete()
 
@@ -33,6 +34,10 @@ db_session.add(user)
 for schedule_type_name in ["Vaccine", "Deworming", "Frontline"]:
     schedule_type = ScheduleType(name=schedule_type_name)
     db_session.add(schedule_type)
+
+for repeat_cycle_name in ["Monthly", "Quarterly", "Yearly"]:
+    repeat_cycle = RepeatCycle(name=repeat_cycle_name)
+    db_session.add(repeat_cycle)
 
 db_session.commit()
 

--- a/petsrus/tests/helper.py
+++ b/petsrus/tests/helper.py
@@ -2,7 +2,7 @@
 import random
 
 from faker import Faker
-from petsrus.models.models import Pet, Schedule, ScheduleType
+from petsrus.models.models import Pet, RepeatCycle, Schedule, ScheduleType
 
 fake = Faker()
 
@@ -59,11 +59,13 @@ def random_schedule(db_session, past=False):
     schedule_type = fake.random_choices(elements=schedule_types, length=1)[0]
     repeats = "YES" if random.randint(0, 1) == 0 else "NO"
     if repeats == "YES":
-        repeat_cycle = fake.random_choices(
-            elements=("MONTHLY", "QUARTERLY", "YEARLY"), length=1
-        )[0]
+        repeat_cycles = [
+            repeat_cycle.id for repeat_cycle in db_session.query(RepeatCycle).all()
+        ]
+        repeat_cycle = fake.random_choices(elements=repeat_cycles, length=1)[0]
     else:
         repeat_cycle = None
+
     # We want some historical schedules
     if past:
         date_of_next = fake.date_this_year(before_today=True, after_today=False)

--- a/petsrus/tests/test_users.py
+++ b/petsrus/tests/test_users.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import logging
 import unittest
 
 from petsrus.models.models import User

--- a/petsrus/views/main.py
+++ b/petsrus/views/main.py
@@ -6,10 +6,22 @@ from datetime import date
 import boto3
 from flask import flash, redirect, render_template, request, url_for
 from flask_login import login_required, login_user, logout_user
-from petsrus.forms.forms import (ChangePetPhotoForm, LoginForm, PetForm,
-                                 PetScheduleForm, RegistrationForm)
-from petsrus.models.models import (Base, Pet, Repeat, Repeat_cycle, Schedule,
-                                   ScheduleType, User)
+from petsrus.forms.forms import (
+    ChangePetPhotoForm,
+    LoginForm,
+    PetForm,
+    PetScheduleForm,
+    RegistrationForm,
+)
+from petsrus.models.models import (
+    Base,
+    Pet,
+    Repeat,
+    RepeatCycle,
+    Schedule,
+    ScheduleType,
+    User,
+)
 from petsrus.petsrus import app, engine, login_manager
 from PIL import Image, UnidentifiedImageError
 from sentry_sdk import capture_exception
@@ -255,11 +267,14 @@ def add_schedule(pet_id):
         (schedule_type.id, schedule_type.name.upper())
         for schedule_type in db_session.query(ScheduleType).order_by("name").all()
     ]
+    form.repeat_cycle.choices = [
+        (repeat_cycle.id, repeat_cycle.name.title())
+        for repeat_cycle in db_session.query(RepeatCycle).order_by("name").all()
+    ]
     if request.method == "POST" and form.validate():
         try:
             pet = db_session.query(Pet).filter_by(id=pet_id).first()
             form.repeats.choices = [Repeat.__values__]
-            form.repeat_cycle.choices = [Repeat_cycle.__values__]
             pet_schedule = Schedule(
                 pet_id=pet.id,
                 date_of_next=form.date_of_next.data,


### PR DESCRIPTION


**Technical Description**

We are now getting the repeat cycle data from the database and not an
enum.

**Reference**

Trello: https://trello.com/c/DWIloM99/18-repeat-cycles-move-to-database